### PR TITLE
feat: add cohort wise segregation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .streamlit
 __pycache__
+.devcontainer

--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ import streamlit as st
 from data import fetch_data
 from script import display_data
 
+# Secrets from .streamlit/secrets.toml
 API_TOKEN = st.secrets["API_TOKEN"]
 API_URL = st.secrets["API_URL"]
 LEAD_URL = st.secrets["LEAD_URL"]
@@ -11,42 +12,62 @@ HEADERS = {
     "xc-token": API_TOKEN
 }
 
-# Streamlit App
+# Streamlit App Setup
 st.set_page_config(page_title="Intern Registrations Dashboard", layout="wide")
 st.title("🎓 Intern Registrations Dashboard")
 
-# Session state setup
+# Initialize session state
 if "intern_type" not in st.session_state:
-    st.session_state.intern_type = None
+    st.session_state.intern_type = "ai"
 if "data" not in st.session_state:
     st.session_state.data = None
+if "cohort_type" not in st.session_state:
+    st.session_state.cohort_type = "cohort1"  # Default to cohort1
 
-# Buttons for intern types
+# Buttons for cohort selection
 col1, col2 = st.columns(2)
 with col1:
-    if st.button("🤖 AI Developer Intern"):
-        st.session_state.intern_type = "ai"
-        with st.spinner("Fetching AI Developer Intern data..."):
-            st.session_state.data = fetch_data(API_URL, HEADERS)
+    if st.button("COHORT 1"):
+        st.session_state.cohort_type = "cohort1"
+        st.session_state.intern_type = None  # Reset intern type
 
 with col2:
-    if st.button("🧑‍💻 Tech Lead Intern"):
-        st.session_state.intern_type = "techlead"
-        with st.spinner("Fetching Tech Lead Intern data..."):
-            st.session_state.data = fetch_data(LEAD_URL, HEADERS)
+    if st.button("COHORT 2"):
+        st.session_state.cohort_type = "cohort2"
+        st.session_state.intern_type = None  # Reset intern type
 
-# Refresh button
-if st.button("🔄 Refresh"):
-    fetch_data.clear()
-    if st.session_state.intern_type:
-        with st.spinner("Refreshing data..."):
-            if st.session_state.intern_type == "techlead":
-                st.session_state.data = fetch_data(LEAD_URL, HEADERS)
-            else:
+# If a cohort is selected
+if st.session_state.cohort_type:
+    st.subheader(f"Selected Cohort: {st.session_state.cohort_type.upper()}")
+
+    # Buttons for intern types
+    col1, col2 = st.columns(2)
+    with col1:
+        if st.button("🤖 AI Developer Intern"):
+            st.session_state.intern_type = "ai"
+            with st.spinner("Fetching AI Developer Intern data..."):
                 st.session_state.data = fetch_data(API_URL, HEADERS)
 
-# Display data if loaded
-if st.session_state.data is not None:
-    display_data(st.session_state.data)
+    with col2:
+        if st.button("🧑‍💻 Tech Lead Intern"):
+            st.session_state.intern_type = "techlead"
+            with st.spinner("Fetching Tech Lead Intern data..."):
+                st.session_state.data = fetch_data(LEAD_URL, HEADERS)
+
+    # Refresh button
+    if st.button("🔄 Refresh"):
+        fetch_data.clear()
+        if st.session_state.intern_type:
+            with st.spinner("Refreshing data..."):
+                if st.session_state.intern_type == "techlead":
+                    st.session_state.data = fetch_data(LEAD_URL, HEADERS)
+                else:
+                    st.session_state.data = fetch_data(API_URL, HEADERS)
+
+    # Display data
+    if st.session_state.data is not None:
+        display_data(st.session_state.data, st.session_state.cohort_type, st.session_state.intern_type)
+    else:
+        st.info("Please select an intern type to load data.")
 else:
-    st.info("Please select an intern type to load data.")
+    st.info("Please select a cohort type.")

--- a/script.py
+++ b/script.py
@@ -2,8 +2,22 @@ import streamlit as st
 import pandas as pd
 import altair as alt
 
-def display_data(data):
+def display_data(data, cohort_type, intern_type):
     df = pd.DataFrame(data)
+
+    if intern_type == "ai":
+        filter_data = 25000
+    elif intern_type == "techlead":
+        filter_data = 1730
+    else:
+        st.info("Please select intern type.")
+        return
+
+
+    if cohort_type == "cohort1":
+        df = df[df['Id'] <= filter_data]
+    else:
+        df = df[df['Id'] > filter_data]
 
     # Rename columns for easier access
     df.rename(columns={


### PR DESCRIPTION
This feature introduces cohort-wise data segregation to the analytics dashboard. Based on the selected cohort_type (e.g., "cohort1" or "cohort2") and intern_type (e.g., "ai" or "techlead"), the dataset is dynamically filtered to separate interns by their cohort.